### PR TITLE
removed 2 lines from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # This is the Official CI/CD for Blazium Engine
-## Note: All Documentation is just thrown in here cause I was yelled at by Dragos......
-### If you think it could be better, make a PR god damnit.
 
 Actions below are all things needed for the CI/CD to work.
 


### PR DESCRIPTION
At the very start of the document should be vital information about what this text is about. First impressions. Having personal stuff especially at the top is useless to 99.9% of users reading this documentation