### PR TITLE
Better looking GitHub changelog with html

### DIFF
--- a/.github/actions/create-github-release/action.yml
+++ b/.github/actions/create-github-release/action.yml
@@ -68,7 +68,8 @@ runs:
             exit 1
           fi
           # BODY_CONTENT=$(cat "$BODY_FILE" | sed 's/\r\r/<br \/>/g' | sed ':a;N;$!ba;s/\n/\r\n/g' | jq -Rsa '.[1:-1]')
-          BODY_CONTENT=$(cat "$BODY_FILE" | sed ':a;N;$!ba;s/\n/<br \/>/g' | jq --raw-output -Rsa '.' | sed 's/^"//;s/"$//')
+          # BODY_CONTENT=$(cat "$BODY_FILE" | sed ':a;N;$!ba;s/\n/<br \/>/g' | jq --raw-output -Rsa '.' | sed 's/^"//;s/"$//')
+          BODY_CONTENT=$(cat "$BODY_FILE")
         elif [[ -n "$BODY" ]]; then
           # BODY_CONTENT=$(echo "$BODY" | sed ':a;N;$!ba;s/\n/\r\n/g' | jq -Rsa '.[1:-1]')
           BODY_CONTENT=$(echo "$BODY" | sed ':a;N;$!ba;s/\n/<br \/>/g' | jq --raw-output -Rsa '.' | sed 's/^"//;s/"$//')

--- a/.github/workflows/deploy_all.yml
+++ b/.github/workflows/deploy_all.yml
@@ -118,6 +118,20 @@ jobs:
         run: |
           node ./cicd/scripts/changelog2txt.js ${{ github.workspace }}/changelog.json
 
+      - name: Generate changelog.html
+        id: changelog
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_OWNER: blazium-engine
+          GITHUB_REPO: blazium
+          BASE_BRANCH: ${{ steps.version.outputs.external_sha }}
+          CURRENT_BRANCH: ${{ steps.get_sha.outputs.sha }}
+          MAJOR_VERSION: ${{ steps.version.outputs.external_major }}
+          MINOR_VERSION: ${{ steps.version.outputs.external_minor }}
+          PATCH_VERSION: ${{ steps.version.outputs.external_patch }}
+        run: |
+          node ./cicd/scripts/changelog2html.js ${{ github.workspace }}/changelog.json
+
       - uses: BetaHuhn/do-spaces-action@v2
         with:
           access_key: ${{ secrets.DO_ACCESS_KEY }}
@@ -137,7 +151,7 @@ jobs:
           TARGET_COMMIT: ${{ inputs.build_sha }}
           TAG_NAME: v${{ inputs.new_version }}${{ github.event.client_payload.type != 'release' && format('-{0}', github.event.client_payload.type || 'nightly') || '' }} 
           NAME: "[${{ github.event.client_payload.type || 'nightly' }}] Blazium Engine v${{ inputs.new_version }}"
-          BODY_FILE: ${{ github.workspace }}/cicd/scripts/changelog.txt
+          BODY_FILE: ${{ github.workspace }}/cicd/scripts/changelog.html
           DRAFT: ${{ github.event.client_payload.type == 'nightly' }}
           PRERELEASE: ${{ github.event.client_payload.type == 'nightly' || github.event.client_payload.type == 'prerelease' }}
           DEBUG: true

--- a/cicd/scripts/changelog2html.js
+++ b/cicd/scripts/changelog2html.js
@@ -1,0 +1,99 @@
+const fs = require('fs');
+const path = require('path');
+
+// Function to generate a templated changelog from the JSON file
+function generateChangelogHTML(jsonFilePath) {
+    try {
+        // Read the JSON file
+        const changelogData = JSON.parse(fs.readFileSync(jsonFilePath, 'utf-8'));
+
+        // Extract data from JSON
+        const {
+            baseBranch,
+            currentBranch,
+            totalCommits,
+            totalPRs,
+            totalFilesChanged,
+            timeSinceFirstChange,
+            timeSinceLastChange,
+            totalContributors,
+            uniqueContributors,
+            changelog,
+            version
+        } = changelogData;
+
+        // Template: Header Section
+        
+        let changelogText = 
+`<h4>Changelog: ${baseBranch} -> ${currentBranch}</h4>
+<h2>Summary:</h2>
+<ul>
+<li><b>Version</b>: <code>${version["major"]}.${version["minor"]}.${version["patch"]}</code></li>
+<li><b>Total Commits</b>: <code>${totalCommits}</code></li>
+<li><b>Total PRs</b>: <code>${totalPRs}</code></li>
+<li><b>Total Files Changed</b>: <code>${totalFilesChanged}</code></li>
+<li><b>Time Since First Change</b>: <code>${timeSinceFirstChange}</code></li>
+<li><b>Time Since Last Change</b>: <code>${timeSinceLastChange}</code></li>
+<li><b>Total Contributors</b>: <code>${totalContributors}</code></li>
+</ul>
+<hr>
+<details><summary><h2>Commits and PRs:</h2></summary>`;
+
+        // Template: Commits and PRs Section
+        changelog.forEach((entry) => {
+            if (!entry.pr) {
+                var [message, details] = entry.message.split(/\n\n/);
+                changelogText +=
+`<details><summary><b>${message}</b></summary>
+<blockquote>
+Commit SHA: ${entry.sha}<br>
+Date: <code>${new Date(entry.date).toLocaleString()}</code><br>
+Author: <b>${entry.user}</b>
+</blockquote>${details ? details.replace(/\n/g, "<br>") : ""}
+<hr></details>`;
+            } 
+        });
+
+        changelogText += `</details><details><summary><h2>Contributors:</h2></summary><ul>`;
+
+        // Template: Contributors Section
+        uniqueContributors.forEach((contributor) => {
+            changelogText += `<li><b>${contributor.username}</b>: <code>${contributor.contributions} contributions</code></li>`;
+        });
+        changelogText += `</ul></details>`
+        const cleanedMessage = changelogText.replace(/\n/g, "");
+        // Export the text file
+        const outputFilePathDetailed = path.join(__dirname, `changelog_${baseBranch}_to_${currentBranch}.html`);
+        const outputFilePathBase = path.join(__dirname, `changelog.html`);
+        fs.writeFileSync(outputFilePathDetailed, cleanedMessage, 'utf-8');
+        fs.writeFileSync(outputFilePathBase, cleanedMessage, 'utf-8');
+        console.log(`Changelog exported with detailed name to ${outputFilePathDetailed}`);
+        console.log(`Changelog exported with base name to ${outputFilePathBase}`);
+    } catch (error) {
+        console.error(`Error processing the JSON file: ${error.message}`);
+    }
+}
+
+// Main function to trigger the changelog generation
+function main() {
+    const args = process.argv.slice(2); // Get the command line arguments
+
+    if (args.length === 0) {
+        console.error('Error: Please provide the path to the JSON file as an argument.');
+        process.exit(1); // Exit with an error code
+    }
+
+    const jsonFilePath = path.resolve(args[0]);
+
+    // Check if the JSON file exists
+    if (!fs.existsSync(jsonFilePath)) {
+        console.error(`Error: The file '${jsonFilePath}' does not exist.`);
+        process.exit(1); // Exit with an error code
+    }
+
+    // Generate the changelog from the provided JSON file
+    generateChangelogHTML(jsonFilePath);
+}
+
+// Execute the main function
+main();


### PR DESCRIPTION
# How it should look like:

<h4>Changelog: ff9bc0422349219b337b015643544a0454d4a7ee -> 192be805edbc075c796cb7ac7344d0a76bbdbb8e</h4><h2>Summary:</h2><ul><li><b>Version</b>: <code>0.2.158</code></li><li><b>Total Commits</b>: <code>250</code></li><li><b>Total PRs</b>: <code>57</code></li><li><b>Total Files Changed</b>: <code>850</code></li><li><b>Time Since First Change</b>: <code>57 days</code></li><li><b>Time Since Last Change</b>: <code>0 days</code></li><li><b>Total Contributors</b>: <code>68</code></li></ul><hr><details><summary><h2>Commits and PRs:</h2></summary><details><summary><b>ResourceLoader: Revert workaround resource loading crashes due to buggy TLS</b></summary><blockquote>Commit SHA: ecd8c21605d8f2a7071047d8fcff08d5fe2a0aac<br>Date: <code>19/11/2024, 00:44:56</code><br>Author: <b>Pedro J. Estébanez</b></blockquote>This reverts commit 41c07856361d7cf2bcbda6d84386b1a0d3969f6a.<hr></details><details><summary><b>Fix use condition_variable after free</b></summary><blockquote>Commit SHA: b792bf506e127cb626dbbef05c231f90af417066<br>Date: <code>19/11/2024, 00:45:10</code><br>Author: <b>Aleksey Vasenev</b></blockquote><hr></details><details><summary><b>ResourceLoader: Properly push & pop TLS state on recursive load tasks</b></summary><blockquote>Commit SHA: 93b3371f07466655c36c7981c4af3cf554412617<br>Date: <code>19/11/2024, 00:45:20</code><br>Author: <b>Pedro J. Estébanez</b></blockquote><hr></details><details><summary><b>ResourceLoader: Enhance deadlock prevention</b></summary><blockquote>Commit SHA: cdc16fddc4ce52034d5d6b3e5810fdb7dbf35312<br>Date: <code>19/11/2024, 00:45:36</code><br>Author: <b>Pedro J. Estébanez</b></blockquote>Benefits:<br>- Simpler code. The main load function is renamed so it's apparent that it's not just a thread entry point anymore.<br>- Cache and thread modes of the original task are honored. A beautiful consequence of this is that, unlike formerly, re-issued loads can use the resource cache, which makes this mechanism much more performant.<br>- The newly added getter for caller task id in WorkerThreadPool allows to remove the custom tracking of that in ResourceLoader.<br>- The check to replace a cached resource and the replacement itself happen atomically. That fixes deadlock prevention leading to multiple resource instances of the same one on disk. As a side effect, it also makes the regular check for replace load mode more robust.<hr></details><details><summary><b>ResourceLoader: Optimize remap check by deferring until a non-mutex zone</b></summary><blockquote>Commit SHA: bb49dc4fe8df7d89a7b0d70b81ebe836029d57f0<br>Date: <code>19/11/2024, 00:46:21</code><br>Author: <b>Pedro J. Estébanez</b></blockquote><hr></details><details><summary><b>ResourceLoader: Fix edge cases in the management of user tokens</b></summary><blockquote>Commit SHA: 807cea00523eb1e5213ef59828bc78df297139f8<br>Date: <code>19/11/2024, 00:46:38</code><br>Author: <b>Pedro J. Estébanez</b></blockquote>1. Make handling of user tokens atomic:<br>   Loads started with the external-facing API used to perform a two-step setup of the user token. Between both, the mutex was unlocked without its reference count having been increased. A non-user-initiated load could therefore destroy the load task when it unreferenced the token.<br>   Those stages now happen atomically so in the one hand, the described race condition can't happen so the load task life insurance doesn't have a gap anymore and, on the other hand, the ugliness that the call to load could return `ERR_BUSY` if happening while other thread was between both steps is gone.<br>   The code has been refactored so the user token concerns are still outside the inner load start function, which is agnostic to that for a cleaner implementation.<hr></details><details><summary><b>WorkerThreadPool (plus friends): Overhaul unlock allowance zones</b></summary><blockquote>Commit SHA: c5987b4073695e9cbacf543495d62dadef80eda1<br>Date: <code>19/11/2024, 00:46:51</code><br>Author: <b>Pedro J. Estébanez</b></blockquote>This fixes a rare but possible deadlock, maybe due to undefined behavior. The new implementation is safer, at the cost of some added boilerplate.<hr></details><details><summary><b>ResourceLoader: Use better error handling for possible engine bugs</b></summary><blockquote>Commit SHA: cd65d5563fb741c4b884e76b375e0e733fb87f09<br>Date: <code>19/11/2024, 00:47:06</code><br>Author: <b>Pedro J. Estébanez</b></blockquote><hr></details><details><summary><b>Change warning muting so it affects all levels, but locally</b></summary><blockquote>Commit SHA: 160c965ac6a3143ceb8021ac35ebe2dcef7c550c<br>Date: <code>19/11/2024, 00:47:37</code><br>Author: <b>Pedro J. Estébanez</b></blockquote><hr></details></details><details><summary><h2>Contributors:</h2></summary><ul><li><b>Pedro J. Estébanez</b>: <code>7 contributions</code></li><li><b>Aleksey Vasenev</b>: <code>1 contributions</code></li></ul></details>