### PR TITLE
add needed entitlement to start app on mac with arguments and missing env vars

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -39,6 +39,9 @@ env:
   TERM: 'xterm'
   DISPLAY: ':0'
   DEPLOY_TYPE: android
+  GODOT_ANDROID_KEYSTORE_ALIAS: ${{ secrets.GODOT_ANDROID_KEYSTORE_ALIAS }}
+  GODOT_ANDROID_SIGN_KEYSTORE_BAS64: ${{ secrets.GODOT_ANDROID_SIGN_KEYSTORE_BAS64 }}
+  GODOT_ANDROID_SIGN_PASSWORD: ${{ secrets.GODOT_ANDROID_SIGN_PASSWORD }}
 
 concurrency:
   group: ci-${{github.actor}}-${{ github.event.client_payload.type || 'nightly' }}-android

--- a/deploy/macos/deploy.entitlements
+++ b/deploy/macos/deploy.entitlements
@@ -12,6 +12,8 @@
  <string>APPLE_TEAM_ID</string>
  <key>com.apple.security.app-sandbox</key>
  <true/>
+ <key>com.apple.security.automation.apple-events</key>
+ <true/>
  <key>com.apple.security.files.user-selected.read-write</key>
  <true/>
  <key>com.apple.security.network.server</key>


### PR DESCRIPTION
Adds entitlement for macos app to start app. Also adds missing env for android.