### PR TITLE
Pin iOS and remaining macOS jobs to macos-15

### DIFF
--- a/.github/workflows/get_apple_sdks.yml
+++ b/.github/workflows/get_apple_sdks.yml
@@ -35,7 +35,7 @@ env:
 jobs:
   build-osxcross-sdk:
     name: Build osxcross SDK for Linux
-    runs-on: macos-latest
+    runs-on: macos-15
     if: false
     steps:
 
@@ -115,7 +115,7 @@ jobs:
 
   gather:
     name: Process XCode SDKs
-    runs-on: "macos-latest"
+    runs-on: macos-15
     steps:
 
       - name: Set up Base Folder

--- a/.github/workflows/get_apple_sdks.yml
+++ b/.github/workflows/get_apple_sdks.yml
@@ -21,7 +21,7 @@ on:
         description: Version of Xcode to copy the SDKs from
         required: true
         type: string
-        default: "15.4"
+        default: "16.2"
       build_type:
         description: nightly, prerelease, release
         required: true
@@ -124,10 +124,16 @@ jobs:
           mkdir -p "$(pwd)/$BASE_FOLDER"
           echo "base_folder=$(pwd)/$BASE_FOLDER" >> $GITHUB_OUTPUT
 
-      - name:  XCode
+      - name: Select Xcode ${{ env.XCODE_VERSION }}
+        run: sudo xcode-select -switch /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
+
+      - name: Verify Xcode selection
         run: |
-          xcode-select --print-path  >> $GITHUB_STEP_SUMMARY
-          sudo xcodebuild -license accept
+          xcode-select -p
+          xcodebuild -version
+
+      - name: Accept Xcode license
+        run: sudo xcodebuild -license accept
 
       - name: List SDKs and Developer Platforms
         run: |

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -67,7 +67,7 @@ jobs:
           is_template: 'true'
 
   build-templates:
-    runs-on: macos-latest
+    runs-on: macos-15
     name: Building ${{ matrix.name }}
     needs: template-check
     if: ${{ needs.template-check.outputs.compile == 'true' || github.event.client_payload.force }}

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -132,9 +132,13 @@ jobs:
           version: ${{ inputs.new_version }}
 
 
-      - uses: maxim-lobanov/setup-xcode@v1.6.0
-        with:
-          xcode-version: '16.1.0'
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.app/Contents/Developer
+
+      - name: Verify Xcode selection
+        run: |
+          xcode-select -p
+          xcodebuild -version
 
       - name: Download and extract MoltenVK
         run: |

--- a/.github/workflows/walledgardens_deploy.yml
+++ b/.github/workflows/walledgardens_deploy.yml
@@ -114,6 +114,14 @@ jobs:
         with:
           repository: blazium-games/ci_cd
           submodules: recursive
+
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.app/Contents/Developer
+
+      - name: Verify Xcode selection
+        run: |
+          xcode-select -p
+          xcodebuild -version
       
       - name: Download Editor
         uses: ./.github/actions/cerebro-download-multi-build

--- a/.github/workflows/walledgardens_deploy.yml
+++ b/.github/workflows/walledgardens_deploy.yml
@@ -103,7 +103,7 @@ jobs:
           echo "Proceed Output: ${{ steps.evaluate.outputs.proceed }}"
 
   deploy-mac-appstore:
-    runs-on: "macos-latest"
+    runs-on: macos-15
     needs: do-we-deploy-lol
     if: >
       needs.do-we-deploy-lol.outputs.proceed == 'true' ||


### PR DESCRIPTION
## Summary
- Pin iOS template builds from macos-latest to macos-15
- Pin Mac App Store deploy job to macos-15
- Pin Apple SDK gathering workflows to macos-15
- macos_builds.yml was already updated in PR #44

## Test plan
- [ ] iOS template CI jobs start on macos-15 and setup-xcode 16.1 succeeds
- [ ] Mac App Store deploy workflow runs on macos-15 when triggered