### PR TITLE
Fix nightly release Version mismatch (#716)

### DIFF
--- a/.github/workflows/deploy_all.yml
+++ b/.github/workflows/deploy_all.yml
@@ -102,8 +102,22 @@ jobs:
           MINOR_VERSION: ${{ inputs.new_minor }}
           PATCH_VERSION: ${{ inputs.new_patch }}
           BUILD_TYPE: ${{ github.event.client_payload.type || 'nightly' }}
+          # Do not re-bump: inputs.new_* already came from runner.yml changelog pass (issue #716).
+          FREEZE_VERSION: "1"
         run: |
           node ./cicd/scripts/changelog.js $(pwd)
+
+      - name: Assert changelog version matches release tag
+        env:
+          EXPECTED_VERSION: ${{ inputs.new_version }}
+        run: |
+          ACTUAL=$(node -e "const v=require('./changelog.json').version; process.stdout.write([v.major,v.minor,v.patch].join('.'))")
+          echo "Expected: ${EXPECTED_VERSION}"
+          echo "Actual:   ${ACTUAL}"
+          if [ "$ACTUAL" != "$EXPECTED_VERSION" ]; then
+            echo "ERROR: changelog.json version (${ACTUAL}) does not match release version (${EXPECTED_VERSION})"
+            exit 1
+          fi
 
       - name: Generate changelog.txt
         id: changelog-txt

--- a/cicd/scripts/changelog.js
+++ b/cicd/scripts/changelog.js
@@ -17,10 +17,16 @@ if (!token || !owner || !repo || !currentBranch || !baseBranch) {
 }
 
 var version = {
-    major: process.env.MAJOR_VERSION || 0,
-    minor: process.env.MINOR_VERSION || 1,
-    patch: process.env.PATCH_VERSION || 0,
+    major: parseInt(process.env.MAJOR_VERSION || "0", 10) || 0,
+    minor: parseInt(process.env.MINOR_VERSION || "1", 10) || 0,
+    patch: parseInt(process.env.PATCH_VERSION || "0", 10) || 0,
     build_type: process.env.BUILD_TYPE || "nightly"
+}
+
+// When set (deploy_all release notes), keep seeded major/minor/patch and only rebuild commit lists.
+const freezeVersion = ["1", "true", "yes"].includes(String(process.env.FREEZE_VERSION || "").toLowerCase());
+if (freezeVersion) {
+    console.log(`[DEBUG] FREEZE_VERSION enabled; locking version at ${version.major}.${version.minor}.${version.patch}`);
 }
 
 var is_version_py_major_greater = false;
@@ -118,17 +124,19 @@ async function setBaseBranch() {
                 patch: parseInt(version_array[2])
             };
 
-            if (prev.major > version.major) {
-                version.major = prev.major;
-                console.log(`[DEBUG] Warning: version.py major number is outdated`);
-            }
-            if (prev.minor > version.minor) {
-                version.minor = prev.minor;
-                console.log(`[DEBUG] Warning: version.py minor number is outdated`);
-            }
-            if (prev.patch > version.patch) {
-                version.patch = prev.patch;
-                console.log(`[DEBUG] Warning: version.py patch number is outdated`);
+            if (!freezeVersion) {
+                if (prev.major > version.major) {
+                    version.major = prev.major;
+                    console.log(`[DEBUG] Warning: version.py major number is outdated`);
+                }
+                if (prev.minor > version.minor) {
+                    version.minor = prev.minor;
+                    console.log(`[DEBUG] Warning: version.py minor number is outdated`);
+                }
+                if (prev.patch > version.patch) {
+                    version.patch = prev.patch;
+                    console.log(`[DEBUG] Warning: version.py patch number is outdated`);
+                }
             }
             console.log(`[DEBUG] Base version: ${version.major}.${version.minor}.${version.patch}`);
 
@@ -267,22 +275,24 @@ async function generateChangelog(outputDir = __dirname) {
             // Track changelog
             changelog.push({ sha: commitSha, message: commitMessage, date: commitDate, user: commitLogin, name: commitUser, pr: prNumber, label: semVerLabel });
 
-            // Versioning
-            if (semVerLabel === "major") {
-                if (!is_version_py_major_greater) {
-                    version.major++;
-                    is_version_py_major_greater = false;
+            // Versioning (skipped when FREEZE_VERSION so deploy_all notes match the frozen tag)
+            if (!freezeVersion) {
+                if (semVerLabel === "major") {
+                    if (!is_version_py_major_greater) {
+                        version.major++;
+                        is_version_py_major_greater = false;
+                    }
+                    version.minor = 0;
+                    version.patch = 0;
+                } else if (semVerLabel === "minor") {
+                    if (!is_version_py_minor_greater) {
+                        version.minor++;
+                        is_version_py_minor_greater = false;
+                    }
+                    version.patch = 0;
+                } else {
+                    version.patch++;
                 }
-                version.minor = 0;
-                version.patch = 0;
-            } else if (semVerLabel === "minor") {
-                if (!is_version_py_minor_greater) {
-                    version.minor++;
-                    is_version_py_minor_greater = false;
-                }
-                version.patch = 0;
-            } else {
-                version.patch++;
             }
 
             if (prNumber) totalPRs++;


### PR DESCRIPTION
## Summary
- Add `FREEZE_VERSION` to `changelog.js` so the deploy pass can rebuild commit lists without re-bumping major/minor/patch.
- Set `FREEZE_VERSION=1` in `deploy_all.yml` and assert `changelog.json` version equals `inputs.new_version`.

Fixes tag/body drift reported in blazium-games/blazium#716 (e.g. tag `v0.6.737-nightly` vs Summary `0.6.745`).

## Test plan
- [x] Local logic dry-run: 8 patch bumps without freeze → `0.6.745`; with freeze → `0.6.737`
- [x] API dry-run against `1e51546...b647f7d` with `FREEZE_VERSION=1` seeded at `0.6.737` → stayed `0.6.737`
- [ ] After merge, next nightly: tag name and Summary `Version:` match
- [ ] Close blazium#716 after verified nightly