### PR TITLE
Fix Windows Cerebro completed notify (Git Bash paths)

### DIFF
--- a/.github/actions/cerebro-completed/action.yml
+++ b/.github/actions/cerebro-completed/action.yml
@@ -37,14 +37,25 @@ runs:
       run: |
         set -euo pipefail
 
+        log_err() {
+          echo "$1"
+          echo "$1" >> "$GITHUB_STEP_SUMMARY"
+        }
+
         CHECKSUM="${{ inputs.checksum }}"
         ARTIFACT="${{ inputs.artifact_path }}"
         if [ -z "$ARTIFACT" ]; then
           ARTIFACT="${GITHUB_WORKSPACE}/$(basename "${{ inputs.file_url }}")"
         fi
+        # Git Bash cannot open mixed Windows paths (D:\a\.../file); normalize first.
+        if command -v cygpath >/dev/null 2>&1; then
+          ARTIFACT="$(cygpath -u "$ARTIFACT")"
+        else
+          ARTIFACT="${ARTIFACT//\\//}"
+        fi
         if [ -z "$CHECKSUM" ]; then
           if [ ! -f "$ARTIFACT" ]; then
-            echo "Error: artifact not found for checksum: $ARTIFACT" >> "$GITHUB_STEP_SUMMARY"
+            log_err "Error: artifact not found for checksum: $ARTIFACT"
             exit 1
           fi
           # Prefer sha256sum (stable hex). openssl -r is not portable across OpenSSL builds
@@ -56,14 +67,14 @@ runs:
           elif command -v openssl >/dev/null 2>&1; then
             CHECKSUM=$(openssl dgst -sha256 "$ARTIFACT" | awk '{print $NF}')
           else
-            echo "Error: no sha256sum/shasum/openssl available to checksum $ARTIFACT" >> "$GITHUB_STEP_SUMMARY"
+            log_err "Error: no sha256sum/shasum/openssl available to checksum $ARTIFACT"
             exit 1
           fi
         fi
         CHECKSUM=$(printf '%s' "$CHECKSUM" | tr -d '\r\n *' | tr '[:upper:]' '[:lower:]')
         if [ -z "$CHECKSUM" ] || ! echo "$CHECKSUM" | grep -Eq '^[a-f0-9]{64}$'; then
-          echo "Error: invalid checksum length/format: ${#CHECKSUM} chars (preview: ${CHECKSUM:0:80})" >> "$GITHUB_STEP_SUMMARY"
-          echo "Artifact: $ARTIFACT ($(wc -c < "$ARTIFACT" | tr -d ' ') bytes)" >> "$GITHUB_STEP_SUMMARY"
+          log_err "Error: invalid checksum length/format: ${#CHECKSUM} chars (preview: ${CHECKSUM:0:80})"
+          log_err "Artifact: $ARTIFACT ($(wc -c < "$ARTIFACT" | tr -d ' ') bytes)"
           exit 1
         fi
 
@@ -76,27 +87,33 @@ runs:
             version: $version
           } + (if ($checksum | length) > 0 then {checksum: $checksum} else {} end)')
 
-        HTTP_CODE=$(curl -sS -o /tmp/cerebro_completed_response.json -w "%{http_code}" \
+        RESP_FILE="${RUNNER_TEMP:-/tmp}/cerebro_completed_response.json"
+        HTTP_CODE=$(curl -sS -o "$RESP_FILE" -w "%{http_code}" \
           -X POST "${{ inputs.cerebro_url }}/api/v1/enginebuilds/${{ inputs.run_id }}/completed/${{ inputs.name }}" \
           -H "Content-Type: application/json" \
           -H "BLAZIUM_AUTH: ${{ inputs.cerebro_auth }}" \
           -d "$BODY")
 
-        response=$(cat /tmp/cerebro_completed_response.json)
+        response=$(cat "$RESP_FILE")
         echo "## Build (Completed)" >> "$GITHUB_STEP_SUMMARY"
         echo "Artifact: $ARTIFACT" >> "$GITHUB_STEP_SUMMARY"
         echo "Checksum length: ${#CHECKSUM}" >> "$GITHUB_STEP_SUMMARY"
         echo "HTTP $HTTP_CODE" >> "$GITHUB_STEP_SUMMARY"
         echo "Response: $response" >> "$GITHUB_STEP_SUMMARY"
+        echo "Artifact: $ARTIFACT"
+        echo "Checksum length: ${#CHECKSUM}"
+        echo "HTTP $HTTP_CODE"
+        echo "Response: $response"
 
         if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
-          echo "Error: Cerebro update failed with HTTP $HTTP_CODE." >> "$GITHUB_STEP_SUMMARY"
+          log_err "Error: Cerebro update failed with HTTP $HTTP_CODE."
           exit 1
         fi
 
         if ! echo "$response" | jq -e '.success == true' >/dev/null 2>&1; then
-          echo "Error: Cerebro update failed." >> "$GITHUB_STEP_SUMMARY"
+          log_err "Error: Cerebro update failed."
           exit 1
         fi
 
+        echo "Cerebro update was successful."
         echo "Cerebro update was successful." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/cerebro-download-build/action.yml
+++ b/.github/actions/cerebro-download-build/action.yml
@@ -47,7 +47,8 @@ runs:
 
         # Check if the request succeeded
         if [[ $(echo "$RESPONSE" | jq -r '.success') != "true" ]]; then
-          echo "Error: Failed to fetch build data. Response: $RESPONSE" >> $GITHUB_STEP_SUMMARY
+          echo "Error: Failed to fetch build data. Response: $RESPONSE"
+          echo "Error: Failed to fetch build data. Response: $RESPONSE" >> "$GITHUB_STEP_SUMMARY"
           exit 1
         fi
 
@@ -68,13 +69,15 @@ runs:
 
         # Check if completed_at is null
         if [[ "$completed_at" == "null" || -z "$completed_at" ]]; then
-          echo "Error: Build is not completed yet (completed_at is null)." >> $GITHUB_STEP_SUMMARY
+          echo "Error: Build is not completed yet (completed_at is null)."
+          echo "Error: Build is not completed yet (completed_at is null)." >> "$GITHUB_STEP_SUMMARY"
           exit 1
         fi
 
         # Check if file_url is valid
         if [[ "$file_url" == "null" || -z "$file_url" ]]; then
-          echo "Error: No file URL provided in the build data." >> $GITHUB_STEP_SUMMARY
+          echo "Error: No file URL provided in the build data."
+          echo "Error: No file URL provided in the build data." >> "$GITHUB_STEP_SUMMARY"
           exit 1
         fi
 
@@ -85,23 +88,34 @@ runs:
       id: download_file
       shell: bash
       run: |
+        set -euo pipefail
+
+        FOLDER="${{ inputs.folder }}"
+        # Git Bash cannot open mixed Windows paths (D:\a\...); normalize first.
+        if command -v cygpath >/dev/null 2>&1; then
+          FOLDER="$(cygpath -u "$FOLDER")"
+        else
+          FOLDER="${FOLDER//\\//}"
+        fi
+
         # Ensure the folder exists
-        if [ ! -d "${{ inputs.folder }}" ]; then
-          echo "Folder ${{ inputs.folder }} does not exist. Creating it."
-          mkdir -p "${{ inputs.folder }}"
+        if [ ! -d "$FOLDER" ]; then
+          echo "Folder $FOLDER does not exist. Creating it."
+          mkdir -p "$FOLDER"
         fi
 
         # Determine the file name and full path
         FILE_NAME=$(basename "${{ steps.parse_build.outputs.file_url }}")
-        FULL_PATH="${{ inputs.folder }}/$FILE_NAME"
+        FULL_PATH="$FOLDER/$FILE_NAME"
 
         # Download the file
         echo "Downloading file from ${{ steps.parse_build.outputs.file_url }} to $FULL_PATH"
-        curl -L -o "$FULL_PATH" "${{ steps.parse_build.outputs.file_url }}"
-        if [ $? -ne 0 ]; then
-          echo "Error: Failed to download the file from ${{ steps.parse_build.outputs.file_url }}" >> $GITHUB_STEP_SUMMARY
+        if ! curl -L -o "$FULL_PATH" "${{ steps.parse_build.outputs.file_url }}"; then
+          echo "Error: Failed to download the file from ${{ steps.parse_build.outputs.file_url }}"
+          echo "Error: Failed to download the file from ${{ steps.parse_build.outputs.file_url }}" >> "$GITHUB_STEP_SUMMARY"
           exit 1
         fi
 
-        echo "File downloaded successfully to $FULL_PATH" >> $GITHUB_STEP_SUMMARY
-        echo "file_path=$FULL_PATH" >> $GITHUB_OUTPUT
+        echo "File downloaded successfully to $FULL_PATH"
+        echo "File downloaded successfully to $FULL_PATH" >> "$GITHUB_STEP_SUMMARY"
+        echo "file_path=$FULL_PATH" >> "$GITHUB_OUTPUT"

--- a/.github/actions/cerebro-download-multi-build/action.yml
+++ b/.github/actions/cerebro-download-multi-build/action.yml
@@ -32,7 +32,13 @@ runs:
       run: |
         # Parse input names as a YAML array
         NAMES=$(echo "${{ inputs.names }}" | awk NF)
-        FOLDER=${{ inputs.folder }}
+        FOLDER="${{ inputs.folder }}"
+        # Git Bash cannot open mixed Windows paths (D:\a\...); normalize first.
+        if command -v cygpath >/dev/null 2>&1; then
+          FOLDER="$(cygpath -u "$FOLDER")"
+        else
+          FOLDER="${FOLDER//\\//}"
+        fi
         CEREBRO_URL=${{ inputs.cerebro_url }}
         CEREBRO_AUTH=${{ inputs.cerebro_auth }}
         RUN_ID=${{ inputs.run_id }}
@@ -141,6 +147,11 @@ runs:
     - name: List All Downloaded Files
       shell: bash
       run: |
-        FOLDER=${{ inputs.folder }}
-        echo "## Listing All Downloaded Files in $FOLDER" >> $GITHUB_STEP_SUMMARY
-        ls -la "$FOLDER" >> $GITHUB_STEP_SUMMARY
+        FOLDER="${{ inputs.folder }}"
+        if command -v cygpath >/dev/null 2>&1; then
+          FOLDER="$(cygpath -u "$FOLDER")"
+        else
+          FOLDER="${FOLDER//\\//}"
+        fi
+        echo "## Listing All Downloaded Files in $FOLDER" >> "$GITHUB_STEP_SUMMARY"
+        ls -la "$FOLDER" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/cerebro-failed/action.yml
+++ b/.github/actions/cerebro-failed/action.yml
@@ -21,16 +21,35 @@ runs:
     - name: Send Cerebro Update
       shell: bash
       run: |
-        response=$(curl -s -X POST "${{ inputs.cerebro_url }}/api/v1/enginebuilds/${{ inputs.run_id }}/failed/${{ inputs.name }}" \
+        set -euo pipefail
+
+        log_err() {
+          echo "$1"
+          echo "$1" >> "$GITHUB_STEP_SUMMARY"
+        }
+
+        RESP_FILE="${RUNNER_TEMP:-/tmp}/cerebro_failed_response.json"
+        HTTP_CODE=$(curl -sS -o "$RESP_FILE" -w "%{http_code}" \
+          -X POST "${{ inputs.cerebro_url }}/api/v1/enginebuilds/${{ inputs.run_id }}/failed/${{ inputs.name }}" \
           -H "Content-Type: application/json" \
           -H "BLAZIUM_AUTH: ${{ inputs.cerebro_auth }}")
 
-        echo "## Build (Failed)" >> $GITHUB_STEP_SUMMARY
-        # Check if the response contains "success": false
-        if echo "$response" | grep -q '"success":false'; then
-          echo "Error: Cerebro update failed." >> $GITHUB_STEP_SUMMARY
-          echo "Response: $response" >> $GITHUB_STEP_SUMMARY
+        response=$(cat "$RESP_FILE")
+        echo "## Build (Failed)" >> "$GITHUB_STEP_SUMMARY"
+        echo "HTTP $HTTP_CODE" >> "$GITHUB_STEP_SUMMARY"
+        echo "Response: $response" >> "$GITHUB_STEP_SUMMARY"
+        echo "HTTP $HTTP_CODE"
+        echo "Response: $response"
+
+        if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+          log_err "Error: Cerebro update failed with HTTP $HTTP_CODE."
           exit 1
-        else
-          echo "Cerebro update was successful." >> $GITHUB_STEP_SUMMARY
         fi
+
+        if echo "$response" | grep -q '"success":false'; then
+          log_err "Error: Cerebro update failed."
+          exit 1
+        fi
+
+        echo "Cerebro update was successful."
+        echo "Cerebro update was successful." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/cerebro-started/action.yml
+++ b/.github/actions/cerebro-started/action.yml
@@ -54,6 +54,11 @@ runs:
       run: |
         set -euo pipefail
 
+        log_err() {
+          echo "$1"
+          echo "$1" >> "$GITHUB_STEP_SUMMARY"
+        }
+
         BODY=$(jq -n \
           --arg name "${{ inputs.name }}" \
           --arg run_id "${{ inputs.run_id }}" \
@@ -80,25 +85,29 @@ runs:
           + (if ($arch | length) > 0 then {arch: $arch} else {} end)
           + (if ($version | length) > 0 then {version: $version} else {} end)')
 
-        HTTP_CODE=$(curl -sS -o /tmp/cerebro_started_response.json -w "%{http_code}" \
+        RESP_FILE="${RUNNER_TEMP:-/tmp}/cerebro_started_response.json"
+        HTTP_CODE=$(curl -sS -o "$RESP_FILE" -w "%{http_code}" \
           -X POST "${{ inputs.cerebro_url }}/api/v1/enginebuilds" \
           -H "Content-Type: application/json" \
           -H "BLAZIUM_AUTH: ${{ inputs.cerebro_auth }}" \
           -d "$BODY")
 
-        response=$(cat /tmp/cerebro_started_response.json)
+        response=$(cat "$RESP_FILE")
         echo "## Build (Started)" >> "$GITHUB_STEP_SUMMARY"
         echo "HTTP $HTTP_CODE" >> "$GITHUB_STEP_SUMMARY"
         echo "Response: $response" >> "$GITHUB_STEP_SUMMARY"
+        echo "HTTP $HTTP_CODE"
+        echo "Response: $response"
 
         if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
-          echo "Error: Cerebro update failed with HTTP $HTTP_CODE." >> "$GITHUB_STEP_SUMMARY"
+          log_err "Error: Cerebro update failed with HTTP $HTTP_CODE."
           exit 1
         fi
 
         if ! echo "$response" | jq -e '.success == true' >/dev/null 2>&1; then
-          echo "Error: Cerebro update failed." >> "$GITHUB_STEP_SUMMARY"
+          log_err "Error: Cerebro update failed."
           exit 1
         fi
 
+        echo "Cerebro update was successful."
         echo "Cerebro update was successful." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- All 12 Windows x86 jobs in [run 30007480318](https://github.com/blazium-games/ci_cd/actions/runs/30007480318) failed at **Notify Cerebro of Build Success** after PR #47 required a local artifact checksum.
- Root cause: `artifact_path` uses `github.workspace` (`D:\a\...`), which Git Bash cannot open without normalization. Windows arm64 jobs succeeded because they run on Ubuntu.
- Normalize paths with `cygpath -u` (fallback: slash rewrite) in `cerebro-completed` and download actions; use `RUNNER_TEMP` for curl response files; echo errors to stdout as well as the step summary.

Relates to: https://github.com/blazium-games/ci_cd/actions/runs/30007480318/job/89218176369

## Test plan
- [ ] Merge and re-run failed Windows Editor/Template jobs on run 30007480318 (or wait for next nightly)
- [ ] Confirm Cerebro completed step succeeds and logs show checksum length 64 + normalized `/d/a/...` artifact path