### PR TITLE
Use 7z to create ZIP archives for releases (#412)

### DIFF
--- a/.github/actions/multi-folder-zip/action.yml
+++ b/.github/actions/multi-folder-zip/action.yml
@@ -89,7 +89,8 @@ runs:
 
           # Attempt to zip the renamed folder
           ZIP_FILE="$OUTPUT_DIR/${NEW_FOLDER_NAME}.zip"
-          (cd "$NEW_FOLDER_PATH" && zip -q -9 -r -D "$ZIP_FILE" .)
+          CREATE_ZIP="${{ github.action_path }}/../../scripts/create_zip.sh"
+          (cd "$NEW_FOLDER_PATH" && bash "$CREATE_ZIP" "$ZIP_FILE" .)
           if [ $? -eq 0 ]; then
             echo "Zipped $NEW_FOLDER_PATH to $ZIP_FILE" >> $GITHUB_STEP_SUMMARY
             ZIPPED_FILES+=("$ZIP_FILE")

--- a/.github/scripts/create_zip.sh
+++ b/.github/scripts/create_zip.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Create a ZIP archive with 7-Zip (DEFLATE, max compression).
+# Keeps standard ZIP format for OS-native extraction (not native .7z).
+#
+# Usage: create_zip.sh <archive_path> <path...>
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "Usage: $0 <archive_path> <path...>" >&2
+  exit 2
+fi
+
+ARCHIVE="$1"
+shift
+
+SEVENZ=""
+if command -v 7z >/dev/null 2>&1; then
+  SEVENZ="7z"
+elif command -v 7za >/dev/null 2>&1; then
+  SEVENZ="7za"
+else
+  echo "Error: 7z/7za not found on PATH. Install p7zip-full (Linux) or sevenzip (macOS/Homebrew)." >&2
+  exit 1
+fi
+
+# Remove existing archive so 7z does not merge/update stale entries.
+rm -f "$ARCHIVE"
+
+"$SEVENZ" a -tzip -bso0 -bd -mx=9 "$ARCHIVE" "$@"

--- a/.github/workflows/editor_deploy.yml
+++ b/.github/workflows/editor_deploy.yml
@@ -115,6 +115,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: blazium-games/ci_cd
+          ref: ${{ github.sha }}
           submodules: recursive
 
       - name: Free Disk Space (Ubuntu)

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -102,8 +102,13 @@ jobs:
       - name: Pull .github folder from ci_cd repository
         run: |
           git clone --depth=1 https://github.com/blazium-games/ci_cd.git ci_cd_repo
+          git -C ci_cd_repo fetch --depth=1 origin ${{ github.sha }}
+          git -C ci_cd_repo checkout ${{ github.sha }}
           cp -r ci_cd_repo/.github/* .github/
           rm -rf ci_cd_repo
+
+      - name: Install sevenzip
+        run: brew install sevenzip
 
       - name: Update new Version Information to version.py
         uses: ./.github/actions/set-repos-version
@@ -245,7 +250,7 @@ jobs:
           cp -r deps/moltenvk/MoltenVK/MoltenVK.xcframework ios_xcode/
           rm -rf ios_xcode/MoltenVK.xcframework/{macos,tvos}*
           cd ios_xcode
-          zip -q -9 -r "${HERE}/${{ matrix.cache-name }}-${{ github.event.client_payload.type || 'nightly' }}.zip" *
+          bash "${GITHUB_WORKSPACE}/.github/scripts/create_zip.sh" "${HERE}/${{ matrix.cache-name }}-${{ github.event.client_payload.type || 'nightly' }}.zip" *
           cd "${HERE}"
           tar -czvf ${{ matrix.cache-name }}-${{ github.event.client_payload.type || 'nightly' }}.tar.gz ${{ matrix.cache-name }}-${{ github.event.client_payload.type || 'nightly' }}.zip
 

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Install binutils
         run: |
           brew update
-          brew install binutils
+          brew install binutils sevenzip
           brew link --overwrite binutils
 
       - name: Remove existing workflows folder
@@ -168,6 +168,8 @@ jobs:
       - name: Pull .github folder from ci_cd repository
         run: |
           git clone --depth=1 https://github.com/blazium-games/ci_cd.git ci_cd_repo
+          git -C ci_cd_repo fetch --depth=1 origin ${{ github.sha }}
+          git -C ci_cd_repo checkout ${{ github.sha }}
           cp -r ci_cd_repo/.github/* .github/
           rm -rf ci_cd_repo
 
@@ -323,7 +325,7 @@ jobs:
             Blazium${MONO_SUFFIX}.app
 
           # Package the application into a zip file
-          zip -q -9 -r "Blazium_macos.universal.zip" Blazium${MONO_SUFFIX}.app
+          bash "${GITHUB_WORKSPACE}/.github/scripts/create_zip.sh" "Blazium_macos.universal.zip" "Blazium${MONO_SUFFIX}.app"
 
           /Applications/Xcode.app/Contents/Developer/usr/bin/notarytool store-credentials "AppleID" --apple-id "${{ secrets.APPLE_ID }}" --password "${{ secrets.APP_SPECIFIC_PASSWORD }}" --team-id "${{ secrets.APPLE_TEAM_ID }}"
 
@@ -332,7 +334,7 @@ jobs:
           xcrun stapler staple Blazium${MONO_SUFFIX}.app
 
           # Package it again after stapling
-          zip -q -9 -r "Blazium_macos.universal.zip" Blazium${MONO_SUFFIX}.app
+          bash "${GITHUB_WORKSPACE}/.github/scripts/create_zip.sh" "Blazium_macos.universal.zip" "Blazium${MONO_SUFFIX}.app"
 
       - name: Upload Editor artifact
         run: |
@@ -444,6 +446,8 @@ jobs:
       - name: Pull .github folder from ci_cd repository
         run: |
           git clone --depth=1 https://github.com/blazium-games/ci_cd.git ci_cd_repo
+          git -C ci_cd_repo fetch --depth=1 origin ${{ github.sha }}
+          git -C ci_cd_repo checkout ${{ github.sha }}
           cp -r ci_cd_repo/.github/* .github/
           rm -rf ci_cd_repo
 
@@ -576,6 +580,8 @@ jobs:
 
       - name: Package Templates
         run: |
+          brew install sevenzip
+
           MONO_SUFFIX=""
           MONO_FSUFFIX=""
           
@@ -595,7 +601,7 @@ jobs:
           chmod +x macos_template.app/Contents/MacOS/blazium*
 
           # Package the application into a zip file
-          zip -q -9 -r "${{ matrix.cache-name }}-${{ github.event.client_payload.type || 'nightly' }}.zip" macos_template.app
+          bash "${GITHUB_WORKSPACE}/.github/scripts/create_zip.sh" "${{ matrix.cache-name }}-${{ github.event.client_payload.type || 'nightly' }}.zip" macos_template.app
           
       
       - name: Create tar.gz Archive

--- a/.github/workflows/template_deploy.yml
+++ b/.github/workflows/template_deploy.yml
@@ -121,6 +121,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: blazium-games/ci_cd
+          ref: ${{ github.sha }}
           submodules: recursive
 
       - name: Free Disk Space (Ubuntu)
@@ -548,7 +549,7 @@ jobs:
               elif [[ "$base" == *.exe ]]; then
                 cp "$f" "$CDN_DIR/$base"
               else
-                (cd "$SRC" && zip -q -9 "$CDN_DIR/${base}.zip" "$base")
+                (cd "$SRC" && bash "$GITHUB_WORKSPACE/.github/scripts/create_zip.sh" "$CDN_DIR/${base}.zip" "$base")
               fi
             done
           }
@@ -579,7 +580,7 @@ jobs:
               elif [[ "$base" == *.exe ]]; then
                 cp "$f" "$CDN_DIR/$mono_name"
               else
-                (cd "${GITHUB_WORKSPACE}/templates/mono" && zip -q -9 "$CDN_DIR/${mono_name}.zip" "$base")
+                (cd "${GITHUB_WORKSPACE}/templates/mono" && bash "$GITHUB_WORKSPACE/.github/scripts/create_zip.sh" "$CDN_DIR/${mono_name}.zip" "$base")
               fi
             done
           fi
@@ -784,8 +785,8 @@ jobs:
             mkdir -p "$RELDIR"
           fi
 
-          # Create the zip file
-          (cd "$TARGET_DIR" && zip -q -9 -r -D "$ZIP_FILE" .)
+          # Create the zip file (ZIP format via 7z for .tpz)
+          (cd "$TARGET_DIR" && bash "$GITHUB_WORKSPACE/.github/scripts/create_zip.sh" "$ZIP_FILE" .)
 
           # Log the result
           if [ $? -eq 0 ]; then
@@ -821,8 +822,8 @@ jobs:
             mkdir -p "$RELDIR"
           fi
 
-          # Create the zip file
-          (cd "$TARGET_DIR" && zip -q -9 -r -D "$ZIP_FILE" .)
+          # Create the zip file (ZIP format via 7z for .tpz)
+          (cd "$TARGET_DIR" && bash "$GITHUB_WORKSPACE/.github/scripts/create_zip.sh" "$ZIP_FILE" .)
 
           # Log the result
           if [ $? -eq 0 ]; then

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -169,6 +169,11 @@ jobs:
           cache-name: ${{ matrix.cache-name }}
         continue-on-error: true
 
+      - name: Install p7zip for web template ZIP compression
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y p7zip-full
+
       - name: Setup Python and SCons
         uses: ./.github/actions/godot-deps
 
@@ -298,6 +303,11 @@ jobs:
         with:
           cache-name: ${{ matrix.cache-name }}
         continue-on-error: true
+
+      - name: Install p7zip for web template ZIP compression
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y p7zip-full
 
       - name: Setup Python and SCons
         uses: ./.github/actions/godot-deps
@@ -502,6 +512,11 @@ jobs:
           cache-name: ${{ matrix.cache-name }}
         continue-on-error: true
 
+      - name: Install p7zip for web template ZIP compression
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y p7zip-full
+
       - name: Setup Python and SCons
         uses: ./.github/actions/godot-deps
 
@@ -667,6 +682,11 @@ jobs:
         with:
           cache-name: ${{ matrix.cache-name }}
         continue-on-error: true
+
+      - name: Install p7zip for web template ZIP compression
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y p7zip-full
 
       - name: Setup Python and SCons
         uses: ./.github/actions/godot-deps


### PR DESCRIPTION
## Summary
- Add `.github/scripts/create_zip.sh` (`7z a -tzip -bso0 -bd -mx=9`) for standard ZIP format with stronger DEFLATE compression.
- Switch editor deploy (`multi-folder-zip`), template deploy (per-file `.zip` and `.tpz`), macOS, and iOS packaging off Info-ZIP `zip -9`.
- Install `sevenzip` on macOS/iOS runners and `p7zip-full` on web build jobs; checkout ci_cd at `github.sha` for deploy jobs so the helper matches the workflow.

Related: https://github.com/blazium-games/blazium/issues/412
Engine companion PR: https://github.com/blazium-games/blazium/pull/730