### PR TITLE
Bake official editor identity in godot-build

### DIFF
--- a/.github/actions/godot-build/action.yml
+++ b/.github/actions/godot-build/action.yml
@@ -32,8 +32,6 @@ runs:
       env:
         SCONSFLAGS: ${{ inputs.sconsflags }}
       run: |
-        echo "Building with flags:" platform=${{ inputs.platform }} target=${{ inputs.target }} tests=${{ inputs.tests }} ${{ env.SCONSFLAGS }} "cache_path=${{ inputs.scons-cache }}" cache_limit=${{ inputs.scons-cache-limit }}
-
         if [ "${{ inputs.target }}" != "editor" ]; then
           # Ensure we don't include editor code in export template builds.
           rm -rf editor
@@ -47,5 +45,15 @@ runs:
           export BUILD_NAME="gh"
         fi
 
-        scons platform=${{ inputs.platform }} target=${{ inputs.target }} tests=${{ inputs.tests }} ${{ env.SCONSFLAGS }} "cache_path=${{ inputs.scons-cache }}" cache_limit=${{ inputs.scons-cache-limit }}
+        EDITOR_IDENTITY=""
+        if [ "${{ inputs.target }}" = "editor" ]; then
+          EDITOR_IDENTITY="editor_crash_reporter=yes editor_analytics=yes editor_app_id=blazium-editor editor_crash_reporter_endpoint=https://crash.blazium.app/v1/reports editor_analytics_endpoint=https://crash.blazium.app/v1/events"
+          if [ -n "${EDITOR_BUILD_ID:-}" ]; then
+            EDITOR_IDENTITY="$EDITOR_IDENTITY editor_build_id=${EDITOR_BUILD_ID}"
+          fi
+        fi
+
+        echo "Building with flags:" platform=${{ inputs.platform }} target=${{ inputs.target }} tests=${{ inputs.tests }} ${{ env.SCONSFLAGS }} $EDITOR_IDENTITY "cache_path=${{ inputs.scons-cache }}" cache_limit=${{ inputs.scons-cache-limit }}
+
+        scons platform=${{ inputs.platform }} target=${{ inputs.target }} tests=${{ inputs.tests }} ${{ env.SCONSFLAGS }} $EDITOR_IDENTITY "cache_path=${{ inputs.scons-cache }}" cache_limit=${{ inputs.scons-cache-limit }}
         ls -l bin/

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -31,6 +31,7 @@ on:
 env:
   # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: blazium-dev
+  EDITOR_BUILD_ID: ${{ inputs.build_sha }}
   SCONSFLAGS: verbose=yes warnings=no progress=no swappy=yes ${{ github.event.client_payload.production && 'production=yes' || '' }}
   BUILD_TYPE: ${{ github.event.client_payload.type || 'nightly' }}
   DOTNET_NOLOGO: true

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -31,6 +31,7 @@ on:
 env:
   # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: blazium-dev
+  EDITOR_BUILD_ID: ${{ inputs.build_sha }}
   SCONSFLAGS: verbose=yes warnings=no progress=no
   TERM: xterm
   DEPLOY_TYPE: ios

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -31,6 +31,7 @@ on:
 env:
   # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: blazium-dev
+  EDITOR_BUILD_ID: ${{ inputs.build_sha }}
   SCONSFLAGS: verbose=yes warnings=no progress=no
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -31,6 +31,7 @@ on:
 env:
   # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: blazium-dev
+  EDITOR_BUILD_ID: ${{ inputs.build_sha }}
   SCONSFLAGS: verbose=yes warnings=no progress=no
   DEPLOY_TYPE: macos
   DEBUG_SCONSFLAGS: debug_symbols=yes separate_debug_symbols=yes debug_paths_relative=yes

--- a/.github/workflows/mono_glue_build.yml
+++ b/.github/workflows/mono_glue_build.yml
@@ -31,6 +31,7 @@ on:
 env:
   # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: blazium-dev
+  EDITOR_BUILD_ID: ${{ inputs.build_sha }}
   SCONSFLAGS: verbose=yes warnings=no progress=no use_static_cpp=no
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -31,6 +31,7 @@ on:
 env:
   # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: blazium-dev
+  EDITOR_BUILD_ID: ${{ inputs.build_sha }}
   SCONSFLAGS: verbose=yes warnings=no progress=no
   EM_VERSION: 3.1.64
   EM_CACHE_FOLDER: "emsdk-cache"

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -33,6 +33,7 @@ env:
   # Used for the cache key. Add version suffix to force clean build.
   GODOT_BASE_BRANCH: blazium-dev
   BLAZIUM_BASE_BRANCH: blazium-dev
+  EDITOR_BUILD_ID: ${{ inputs.build_sha }}
   SCONSFLAGS: verbose=yes warnings=no progress=no module_text_server_fb_enabled=yes d3d12=yes strict_checks=yes module_xbox_module_enabled=no use_mingw=no "angle_libs=${{ github.workspace }}/"
   SCONS_CACHE_MSVC_CONFIG: true
   DEPLOY_TYPE: windows


### PR DESCRIPTION
## Summary
- When `godot-build` target is `editor`, append official `editor_*` flags (`blazium-editor`, crash/analytics URLs).
- Set `EDITOR_BUILD_ID` from `inputs.build_sha` on live editor-building workflows; omit `editor_build_id` if empty so the engine falls back to `VERSION_HASH`.
- Official templates stay unlocked (no `template_*` or `crash_reporter=yes`/`analytics=yes`).

## Test plan
- [ ] Editor jobs log `editor_app_id=blazium-editor` and the build SHA
- [ ] Template jobs do not receive `editor_*` or `template_*` identity flags
- [ ] `old/` and `windows_builds-old-mingw.yml` are unchanged