### PR TITLE
Keep editor crash identity bakes

### DIFF
--- a/.github/actions/godot-build/action.yml
+++ b/.github/actions/godot-build/action.yml
@@ -46,6 +46,8 @@ runs:
         fi
 
         EDITOR_IDENTITY=""
+        # Editor identity is passed on the CLI to the crash reporter sidecar and must stay non-empty.
+        # Do not stamp reporter_sha256 on official editors; Hub resolves the sidecar by filename only.
         if [ "${{ inputs.target }}" = "editor" ]; then
           EDITOR_IDENTITY="editor_crash_reporter=yes editor_analytics=yes editor_app_id=blazium-editor editor_crash_reporter_endpoint=https://crash.blazium.app/v1/reports editor_analytics_endpoint=https://crash.blazium.app/v1/events"
           if [ -n "${EDITOR_BUILD_ID:-}" ]; then


### PR DESCRIPTION
## Summary
- Keep official editor identity SCons bakes (`editor_app_id`, endpoint, optional `editor_build_id`).
- Document that those values are passed on the CLI to the sidecar and must stay non-empty.
- Do not stamp `reporter_sha256` on official editors.

## Test plan
- [ ] Editor builds still receive `editor_app_id=blazium-editor` and the crash endpoint.
- [ ] No workflow writes `reporter_sha256` for the sidecar.